### PR TITLE
Adds capability to attach existing security groups to Opensearch domain

### DIFF
--- a/opensearch_domain.tf
+++ b/opensearch_domain.tf
@@ -72,7 +72,7 @@ resource "aws_opensearch_domain" "default" {
     for_each = var.vpc_enabled ? [true] : []
 
     content {
-      security_group_ids = [join("", aws_security_group.default[*].id)]
+      security_group_ids = var.create_security_group ? [join("", aws_security_group.default[*].id)] : var.security_groups
       subnet_ids         = var.subnet_ids
     }
   }


### PR DESCRIPTION
## what

- Adds capability to attach existing security groups to Opensearch domain by setting var.create_security_group to false
- Almost all the necessary settings already exist to support this functionality, as it aligns with how the module currently handles security group configuration for the OpenSearch domain


## why


- This modification enables users to either create a new security group or specify existing ones via the var.security_groups variable. This is especially useful for integrating with externally managed security groups.
- We expect to use existing security groups to attach to the OpenSearch domain in cases where we don’t want to use the security group created by the module.
- The var.security_groups variable already exists and accepts a list of security group IDs that can be directly applied to the OpenSearch domain.


## references
https://github.com/cloudposse/terraform-aws-elasticsearch/pull/134
